### PR TITLE
use include guard to prevent redefinition for fabs()

### DIFF
--- a/src/ParOptComplexStep.h
+++ b/src/ParOptComplexStep.h
@@ -23,11 +23,14 @@ inline double ParOptRealPart( const double& r ){
 }
 
 // Compute the absolute value
+#ifndef FABS_COMPLEX_IS_DEFINED  //prevent redefinition
+#define FABS_COMPLEX_IS_DEFINED
 inline std::complex<double> fabs( const std::complex<double>& c ){
   if (real(c) < 0.0){
     return -c;
   }
   return c;
 }
+#endif // FABS_COMPLEX_IS_DEFINED
 
 #endif // PAROPT_COMPLEX_STEP_H


### PR DESCRIPTION
Since the helper function fabs() has exact same definition in tacs/src/TacsComplexStep.h and paropt/src/ParOptComplexStep.h, the build of TMR interface will fail because it includes both headers that such a redefinition will cause complication error. Here a solution is proposed that uses compiler directive to prevent redefinition.