### PR TITLE
Updated TOML file for NumPy version dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=3.0.0', 'oldest-supported-numpy', 'mpi4py']
+requires = ['setuptools>=45.0', 'wheel', 'cython>=3.0.0', 'numpy>=2.0', 'mpi4py']


### PR DESCRIPTION
Reason for suggested change:  the "oldest-supported-numpy" package was deprecated. 

Solution: use of NumPy versions 2.0 and greater at build time still allows users to work with NumPy 1.xx or versions greater than 2.0. Without this change, only NumPy versions 1.xx were supported, so, if a user had a NumPy version of 2.0 or greater, a binary incompatibility issue would be raised. With the updated TOML, this issue was not raised when testing with NumPy 1.26.0 or 2.2.6.